### PR TITLE
Typo in Maven plugin docs

### DIFF
--- a/docs/plugins/web3j_maven_plugin.md
+++ b/docs/plugins/web3j_maven_plugin.md
@@ -41,7 +41,7 @@ The are several variable to select the solidity source files, define a source de
 | `<nativeJavaType/>`    | Creates Java Native Types (instead of Solidity Types)                                  | `true`                          |
 | `<soliditySourceFiles>`| Standard maven [fileset](https://maven.apache.org/shared/file-management/fileset.html) | `<soliditySourceFiles>`<br>`  <directory>src/main/resources</directory>`<br>`  <includes>`<br>`    <include>**/*.sol</include>`<br>`  </includes>`<br>`</soliditySourceFiles>`  |
 | `<contract>`           | Filter (`<include>` or `<exclude>`) contracts based on the name.                       | `<contract>`<br>`  <includes>`<br>`    <include>greeter</include>`<br>`  </includes>`<br>`  <excludes>`<br>`    <exclude>mortal</exclude>`<br>`  <excludes>`<br>`</contracts>`  |
-| `<pathPrefixes>`       | A list (`<pathPrefixe>`) of replacements of dependency replacements inside Solidity contract.  |  |
+| `<pathPrefixes>`       | A list (`<pathPrefix>`) of replacements of dependency replacements inside Solidity contract.  |  |
 
 Configuration of `outputDirectory` has priority over `sourceDestination`
 


### PR DESCRIPTION
### What does this PR do?
Fixes a minor typo in the Maven plugin documentation.  Where it says `pathPrefixe`, it should say `pathPrefix`.

### Where should the reviewer start?
The only document this PR affects: `docs/plugins/web3j_maven_plugin.md`

### Why is it needed?
It is just a cosmetic change. Increases the readability of the documentation.
