### PR TITLE
Changing deprecated load and deploy methods to non-deprecated one

### DIFF
--- a/docs/advanced/ethereum_name_service.md
+++ b/docs/advanced/ethereum_name_service.md
@@ -14,7 +14,7 @@ You can use ENS names anywhere you wish to transact in web3j. In practice this m
 
 ```java
 YourSmartContract contract = YourSmartContract.load(
-        "0x<address>|<ensName>", web3j, credentials, GAS_PRICE, GAS_LIMIT);
+        "0x<address>|<ensName>", web3j, credentials, contractGasProvider);
 ```
 
 Also, when performing Ether transfers, such as using the command line

--- a/docs/getting_started/deploy_interact_smart_contracts.md
+++ b/docs/getting_started/deploy_interact_smart_contracts.md
@@ -23,7 +23,7 @@ Credentials credentials = WalletUtils.loadCredentials("password", "/path/to/wall
 
 YourSmartContract contract = YourSmartContract.deploy(
         <web3j>, <credentials>,
-        GAS_PRICE, GAS_LIMIT,
+        <contractGasProvider>,
         <param1>, ..., <paramN>).send();  // constructor params
 ```
 
@@ -31,7 +31,7 @@ Or use an existing contract:
 
 ```java
 YourSmartContract contract = YourSmartContract.load(
-        "0x<address>|<ensName>", <web3j>, <credentials>, GAS_PRICE, GAS_LIMIT);
+        "0x<address>|<ensName>", <web3j>, <credentials>, <contractGasProvider>);
 ```
 
 To transact with a smart contract:

--- a/docs/smart_contracts/construction_and_deployment.md
+++ b/docs/smart_contracts/construction_and_deployment.md
@@ -5,7 +5,7 @@ Construction and deployment of smart contracts happens with the *deploy* method:
 
 ```java
 YourSmartContract contract = YourSmartContract.deploy(
-        <web3j>, <credentials>, GAS_PRICE, GAS_LIMIT,
+        <web3j>, <credentials>, <contractGasProvider>,
         [<initialValue>,]
         <param1>, ..., <paramN>).send();
 ```
@@ -19,7 +19,7 @@ simply pass in it's address:
 
 ```java
 YourSmartContract contract = YourSmartContract.load(
-        "0x<address>|<ensName>", web3j, credentials, GAS_PRICE, GAS_LIMIT);
+        "0x<address>|<ensName>", web3j, credentials, contractGasProvider);
 ```
 
 Deploying and interacting with smart contracts

--- a/docs/smart_contracts/interacting_with_smart_contract.md
+++ b/docs/smart_contracts/interacting_with_smart_contract.md
@@ -7,7 +7,7 @@ However, you may wish to modify the transaction manager, which you can pass to t
 
 ```java
 YourSmartContract contract = YourSmartContract.deploy(
-        <web3j>, <transactionManager>, GAS_PRICE, GAS_LIMIT,
+        <web3j>, <transactionManager>, <contractGasProvider>,
         <param1>, ..., <paramN>).send();
 ```
 


### PR DESCRIPTION
### What does this PR do?
This PR closes issue #65.

### Where should the reviewer start?
Reviewer can start from issue #65 and [web3j docs](https://docs.web3j.io/4.8.7/getting_started/deploy_interact_smart_contracts/) where a reviewer can observe that docs are showing the deprecated deploy and load methods, I made the changes for non-deprecated methods.

### Why is it needed?
This will encourage the users to use the latest bug free methods.