### PR TITLE
Added nodereal as ethereum node provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Features
 -   Reactive-functional API for working with filters
 -   [Ethereum Name Service (ENS)](https://ens.domains/) support
 -   Support for OpenEthereum's [Personal](https://openethereum.github.io/wiki/JSONRPC-personal-module), and Geth's [Personal](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal) client APIs
--   Support for [Alchemy](https://alchemyapi.io/) and [Infura](https://infura.io/), so you don't have to run an Ethereum client yourself
+-   Support for [Alchemy](https://alchemyapi.io/), [Infura](https://infura.io/) and [Nodereal] (https://nodereal.io), so you don't have to run an Ethereum client yourself
 -   Support for ERC20 and ERC721 token standards
 -   Comprehensive integration tests demonstrating a number of the above scenarios
 -   Command line tools


### PR DESCRIPTION
Added Nodereal as Ethereum node provider

### What does this PR do?
Adds another new Ethereum Node provider
*required*

### Where should the reviewer start?
Web3j-docs
### Why is it needed?
Addition to another option for Developers to use as a node service