### PR TITLE
fix(ci): correct mike set-default invocation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Deploy with Mike
         run: mike deploy --update-alias ${{ env.version }} latest -p
       - name: Set default version with Mike
-        run: mike set-default ${{ env.version }} latest -p
+        run: mike set-default latest -p


### PR DESCRIPTION
## Summary

This PR fixes the documentation deployment workflow by correcting the `mike set-default` command.

## What changed

* Updated the GitHub Actions workflow in `.github/workflows/deploy.yaml`.
* Replaced the invalid command:

  ```bash
  mike set-default ${{ env.version }} latest -p
  ```

  with:

  ```bash
  mike set-default latest -p
  ```

## Root cause

`mike set-default` accepts only a single positional argument (the version or alias to set as the default). The workflow was passing both the version (`5.0.3`) and the `latest` alias, causing the deployment to fail with:

```text
mike: error: unrecognized arguments: latest
```

## Result

The deployment workflow now completes successfully, and the documentation root continues to point to the `latest` alias, which is updated during the preceding `mike deploy --update-alias ... latest` step.
